### PR TITLE
Add UTP and WebSockets to the mix

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   "homepage": "https://github.com/whyrusleeping/js-mafmt#readme",
   "devDependencies": {
     "pre-commit": "^1.1.2",
-    "standard": "^5.4.1",
+    "standard": "^6.0.8",
     "tape": "^4.4.0"
   },
   "dependencies": {
-    "multiaddr": "^1.1.1"
+    "multiaddr": "^1.3.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ var IP = or(base('ip4'), base('ip6'))
 var TCP = and(IP, base('tcp'))
 var UDP = and(IP, base('udp'))
 var UTP = and(UDP, base('utp'))
+var WebSockets = and(TCP, base('websockets'))
 var Reliable = or(TCP, UTP)
 var IPFS = and(Reliable, base('ipfs'))
 
@@ -11,6 +12,7 @@ exports.IP = IP
 exports.TCP = TCP
 exports.UDP = UDP
 exports.UTP = UTP
+exports.WebSockets = WebSockets
 exports.Reliable = Reliable
 exports.IPFS = IPFS
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -32,18 +32,25 @@ test('basic stuff works', function (t) {
     '/ip6/fc00::/tcp/5523/udp/9543'
   ]
 
-  /*
-  	var good_utp = [
-  		"/ip4/1.2.3.4/udp/3456/utp",
-  		"/ip6/::/udp/0/utp",
-  	]
+  var good_utp = [
+    '/ip4/1.2.3.4/udp/3456/utp',
+    '/ip6/::/udp/0/utp'
+  ]
 
-  	var bad_utp = [
-  		"/ip4/0.0.0.0/tcp/12345/utp",
-  		"/ip6/1.2.3.4/ip4/0.0.0.0/udp/1234/utp",
-  		"/utp",
-  	]
-  	*/
+  var bad_utp = [
+    '/ip4/0.0.0.0/tcp/12345/utp',
+    '/ip6/::/ip4/0.0.0.0/udp/1234/utp'
+  ]
+
+  var good_websockets = [
+    '/ip4/1.2.3.4/tcp/3456/websockets',
+    '/ip6/::/tcp/0/websockets'
+  ]
+
+  var bad_websockets = [
+    '/ip4/0.0.0.0/tcp/12345/udp/2222/websockets',
+    '/ip6/::/ip4/0.0.0.0/udp/1234/websockets'
+  ]
 
   function assertMatches (p) {
     var tests = Array.from(arguments).slice(1)
@@ -60,7 +67,7 @@ test('basic stuff works', function (t) {
     var tests = Array.from(arguments).slice(1)
     tests.forEach(function (test) {
       test.forEach(function (testcase) {
-        t.equal(p.matches(testcase), false, 'should not have matched: ' + testcase + ' ' + p)
+        t.equal(p.matches(testcase), false, 'should not have matched: ' + testcase + ' ' + test)
       })
     })
   }
@@ -72,15 +79,16 @@ test('basic stuff works', function (t) {
   assertMismatches(mafmt.TCP, bad_tcp, good_ip)
 
   assertMatches(mafmt.UDP, good_udp)
-  assertMismatches(mafmt.UDP, bad_udp, good_ip, good_tcp /*, good_utp*/)
+  assertMismatches(mafmt.UDP, bad_udp, good_ip, good_tcp, good_utp)
 
-  /*
   assertMatches(mafmt.UTP, good_utp)
   assertMismatches(mafmt.UTP, bad_utp, good_ip, good_tcp, good_udp)
 
   assertMatches(mafmt.Reliable, good_utp, good_tcp)
   assertMismatches(mafmt.Reliable, good_ip, good_udp)
-  */
+
+  assertMatches(mafmt.WebSockets, good_websockets)
+  assertMismatches(mafmt.WebSockets, good_ip, good_udp, bad_websockets)
 
   t.end()
 })


### PR DESCRIPTION
@whyrusleeping I've updated js-multiaddr to support uTP (and WebSockets, HTTP and so on) and here is the PR to make js-mafmt to make it understand uTP and WebSockets as well (as I need it for libp2p).