### PR TITLE
feat: adding circuit addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist
 coverage
 
 *.log
+
+.vscode
+.history

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "David Dias <daviddias.p@gmail.com>",
     "Jeromy <jeromyj@gmail.com>",
     "Jeromy Johnson <why@ipfs.io>",
-    "dignifiedquire <dignifiedquire@gmail.com>"
+    "dignifiedquire <dignifiedquire@gmail.com>",
+    "dmitriy ryajov <dryajov@dmitriys-MBP.HomeNET>"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mafmt",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "A multiaddr validator",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
   },
   "homepage": "https://github.com/whyrusleeping/js-mafmt#readme",
   "devDependencies": {
-    "aegir": "^9.3.3",
+    "aegir": "^11.0.0",
     "chai": "^3.5.0",
     "pre-commit": "^1.2.2"
   },
   "dependencies": {
-    "multiaddr": "^2.2.0"
+    "multiaddr": "^2.2.2"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ const Circuit = or(
   and(_IPFS, base('p2p-circuit'), _IPFS),
   and(_IPFS, base('p2p-circuit')),
   and(base('p2p-circuit'), _IPFS),
+  and(Reliable, base('p2p-circuit')),
   base('p2p-circuit')
 )
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const multiaddr = require('multiaddr')
  */
 const DNS4 = base('dns4')
 const DNS6 = base('dns6')
-const DNS = or(
+const _DNS = or(
   base('dns'),
   DNS4,
   DNS6
@@ -17,6 +17,11 @@ const IP = or(base('ip4'), base('ip6'))
 const TCP = and(IP, base('tcp'))
 const UDP = and(IP, base('udp'))
 const UTP = and(UDP, base('utp'))
+
+const DNS = or(
+  and(_DNS, base('tcp')),
+  _DNS
+)
 
 const WebSockets = or(
   and(TCP, base('ws')),

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,8 @@ const Circuit = or(
 
 const IPFS = or(
   and(_IPFS, Circuit),
+  and(Circuit, _IPFS),
+  Circuit,
   _IPFS
 )
 

--- a/src/index.js
+++ b/src/index.js
@@ -51,9 +51,22 @@ const Reliable = or(
   UTP
 )
 
-const IPFS = or(
+let _IPFS = or(
   and(Reliable, base('ipfs')),
-  WebRTCStar
+  WebRTCStar,
+  base('ipfs')
+)
+
+const Circuit = or(
+  and(_IPFS, base('p2p-circuit'), _IPFS),
+  and(_IPFS, base('p2p-circuit')),
+  and(base('p2p-circuit'), _IPFS),
+  base('p2p-circuit')
+)
+
+const IPFS = or(
+  and(_IPFS, Circuit),
+  _IPFS
 )
 
 exports.DNS = DNS
@@ -69,6 +82,7 @@ exports.WebSocketsSecure = WebSocketsSecure
 exports.WebRTCStar = WebRTCStar
 exports.WebRTCDirect = WebRTCDirect
 exports.Reliable = Reliable
+exports.Circuit = Circuit
 exports.IPFS = IPFS
 
 /*

--- a/src/index.js
+++ b/src/index.js
@@ -62,15 +62,24 @@ let _IPFS = or(
   base('ipfs')
 )
 
-const Circuit = or(
+const _Circuit = or(
   and(_IPFS, base('p2p-circuit'), _IPFS),
   and(_IPFS, base('p2p-circuit')),
   and(base('p2p-circuit'), _IPFS),
   and(Reliable, base('p2p-circuit')),
+  and(base('p2p-circuit'), Reliable),
   base('p2p-circuit')
 )
 
+const CircuitRecursive = () => or(
+  and(_Circuit, CircuitRecursive),
+  _Circuit
+)
+
+const Circuit = CircuitRecursive()
+
 const IPFS = or(
+  and(Circuit, _IPFS, Circuit),
   and(_IPFS, Circuit),
   and(Circuit, _IPFS),
   Circuit,
@@ -116,7 +125,7 @@ function and () {
       return null
     }
     args.some(function (arg) {
-      a = arg.partialMatch(a)
+      a = typeof arg === 'function' ? arg().partialMatch(a) : arg.partialMatch(a)
       if (a === null) {
         return true
       }
@@ -149,7 +158,7 @@ function or () {
   function partialMatch (a) {
     let out = null
     args.some(function (arg) {
-      const res = arg.partialMatch(a)
+      const res = typeof arg === 'function' ? arg().partialMatch(a) : arg.partialMatch(a)
       if (res) {
         out = res
         return true
@@ -171,6 +180,7 @@ function or () {
 
 function base (n) {
   const name = n
+
   function matches (a) {
     if (typeof a === 'string') {
       a = multiaddr(a)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -92,11 +92,23 @@ describe('multiaddr validation', function () {
     '/ip6/::/ip4/0.0.0.0/udp/1234/wss'
   ]
 
+  const goodCircuit = [
+    '/p2p-circuit',
+    '/p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
+    '/p2p-circuit/ip4/127.0.0.1/tcp/20008/ws/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
+    '/p2p-circuit/libp2p-webrtc-star/ip4/1.2.3.4/tcp/3456/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
+    '/p2p-circuit/ip4/1.2.3.4/tcp/3456/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4'
+  ]
+
   const goodIPFS = [
     '/ip4/127.0.0.1/tcp/20008/ws/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
     '/libp2p-webrtc-star/ip4/1.2.3.4/tcp/3456/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
-    '/ip4/1.2.3.4/tcp/3456/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4'
+    '/ip4/1.2.3.4/tcp/3456/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
+    '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit',
+    '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj'
   ]
+
+  goodIPFS.concat(goodCircuit)
 
   function assertMatches (p) {
     const tests = Array.from(arguments).slice(1)
@@ -164,6 +176,10 @@ describe('multiaddr validation', function () {
   it('WebRTC-direct validation', function () {
     assertMatches(mafmt.WebRTCDirect, goodWebRTCDirect)
     assertMismatches(mafmt.WebRTCDirect, goodIP, goodUDP, badWS)
+  })
+
+  it('Circuit validation', function () {
+    assertMatches(mafmt.Circuit, goodCircuit)
   })
 
   it('IPFS validation', function () {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -10,7 +10,10 @@ describe('multiaddr validation', function () {
     '/dns/ipfs.io',
     '/dns4/ipfs.io',
     '/dns4/libp2p.io',
-    '/dns6/protocol.ai'
+    '/dns6/protocol.ai',
+    '/dns4/protocol.ai/tcp/80',
+    '/dns6/protocol.ai/tcp/80',
+    '/dns/protocol.ai/tcp/80'
   ]
 
   const badDNS = [

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -102,7 +102,9 @@ describe('multiaddr validation', function () {
     '/p2p-circuit/libp2p-webrtc-star/ip4/1.2.3.4/tcp/3456/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/p2p-circuit/ip4/1.2.3.4/tcp/3456/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/p2p-circuit/ip4/127.0.0.1/tcp/4002/ipfs/QmddWMcQX6orJGHpETYMyPgXrCXCtYANMFVDCvhKoDwLqA',
-    '/p2p-circuit/ipfs/QmddWMcQX6orJGHpETYMyPgXrCXCtYANMFVDCvhKoDwLqA'
+    '/p2p-circuit/ipfs/QmddWMcQX6orJGHpETYMyPgXrCXCtYANMFVDCvhKoDwLqA',
+    '/p2p-circuit/ip4/127.0.0.1/tcp/20008/ws/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj/' +
+    'p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj'
   ]
 
   const goodIPFS = [

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -97,7 +97,9 @@ describe('multiaddr validation', function () {
     '/p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
     '/p2p-circuit/ip4/127.0.0.1/tcp/20008/ws/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
     '/p2p-circuit/libp2p-webrtc-star/ip4/1.2.3.4/tcp/3456/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
-    '/p2p-circuit/ip4/1.2.3.4/tcp/3456/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4'
+    '/p2p-circuit/ip4/1.2.3.4/tcp/3456/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
+    '/p2p-circuit/ip4/127.0.0.1/tcp/4002/ipfs/QmddWMcQX6orJGHpETYMyPgXrCXCtYANMFVDCvhKoDwLqA',
+    '/p2p-circuit/ipfs/QmddWMcQX6orJGHpETYMyPgXrCXCtYANMFVDCvhKoDwLqA'
   ]
 
   const goodIPFS = [
@@ -106,9 +108,7 @@ describe('multiaddr validation', function () {
     '/ip4/1.2.3.4/tcp/3456/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit',
     '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj'
-  ]
-
-  goodIPFS.concat(goodCircuit)
+  ].concat(goodCircuit)
 
   function assertMatches (p) {
     const tests = Array.from(arguments).slice(1)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -107,6 +107,14 @@ describe('multiaddr validation', function () {
     'p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj'
   ]
 
+  const badCircuit = [
+    '/ip4/0.0.0.0/tcp/12345/udp/2222/wss',
+    '/ip4/0.0.7.6/udp/1234',
+    '/ip6/::/udp/0/utp',
+    '/dns/ipfs.io/ws',
+    '/libp2p-webrtc-direct/ip4/1.2.3.4/tcp/3456/http'
+  ]
+
   const goodIPFS = [
     '/ip4/127.0.0.1/tcp/20008/ws/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
     '/libp2p-webrtc-star/ip4/1.2.3.4/tcp/3456/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
@@ -185,6 +193,7 @@ describe('multiaddr validation', function () {
 
   it('Circuit validation', function () {
     assertMatches(mafmt.Circuit, goodCircuit)
+    assertMismatches(mafmt.Circuit, badCircuit)
   })
 
   it('IPFS validation', function () {


### PR DESCRIPTION
My attempt at implementing the p2p-circuit addresses, please review. This is still using the /ipfs instead of the /p2p id.

@whyrusleeping @diasdavid @dignifiedquire @lgierth

needs https://github.com/multiformats/js-multiaddr/pull/41